### PR TITLE
Fix redirect in web client

### DIFF
--- a/web/src/http/redirect.tsx
+++ b/web/src/http/redirect.tsx
@@ -1,17 +1,25 @@
 import { useQuery, type UseQueryResult } from 'react-query';
-import { api } from './api';
-import type { AxiosError, AxiosResponse } from 'axios';
+
+const API_URL = import.meta.env.VITE_API_URL;
 
 export const REDIRECT_QUERY_KEY = 'redirect';
 
-export const redirect = async (shortUrl: string): Promise<AxiosResponse<void>> => {
-  return api.get(`/${shortUrl}`);
+export const redirect = async (shortUrl: string): Promise<Response> => {
+  const response = await fetch(`${API_URL}/${shortUrl}`, {
+    // Do not automatically follow redirects so we can detect a 302 status
+    redirect: 'manual',
+  });
+
+  if (response.status === 404) {
+    throw new Error('Not Found');
+  }
+
+  return response;
 };
 
-export const useRedirect = (shortUrl: string): UseQueryResult<AxiosResponse<void>, AxiosError> =>
+export const useRedirect = (shortUrl: string): UseQueryResult<Response, Error> =>
   useQuery({
     queryKey: [REDIRECT_QUERY_KEY, shortUrl],
     queryFn: () => redirect(shortUrl),
     enabled: !!shortUrl,
-    retry: false,
-  });
+    retry: false,  });

--- a/web/src/pages/Redirecting.tsx
+++ b/web/src/pages/Redirecting.tsx
@@ -2,23 +2,22 @@ import { useNavigate, useParams } from 'react-router-dom';
 import { LogoIcon } from '../components/icons/LogoIcon';
 import { PageStatus } from '../layouts/PageStatus';
 import { useEffect } from 'react';
-import type { AxiosError } from 'axios';
 import { useRedirect } from '../http/redirect';
 
 export const Redirecting = () => {
    const { shortUrl } = useParams<{ shortUrl: string }>();
   const navigate = useNavigate();
 
-  const { isSuccess, error } = useRedirect(shortUrl ?? '');
+  const { isSuccess, data, error } = useRedirect(shortUrl ?? '');
 
   useEffect(() => {
-    if (isSuccess && shortUrl) {
-      window.location.href = `http://localhost:3333/${shortUrl}`;
+    if (isSuccess && shortUrl && data?.status === 302) {
+      window.location.href = `${import.meta.env.VITE_API_URL}/${shortUrl}`;
     }
-  }, [isSuccess, shortUrl]);
+  }, [isSuccess, shortUrl, data]);
 
   useEffect(() => {
-    if (error && (error as AxiosError).response?.status === 404) {
+    if (error) {
       navigate('/*');
     }
   }, [error, navigate]);
@@ -34,7 +33,7 @@ export const Redirecting = () => {
             {' '}
             Não foi redirecionado?{' '}
             <a
-              href={`http://localhost:3333/${shortUrl ?? ''}`}
+              href={`${import.meta.env.VITE_API_URL}/${shortUrl ?? ''}`}
               className="text-blue-base underline"
             >
               Acesse aqui


### PR DESCRIPTION
## Summary
- prevent React query from following cross-origin redirects
- redirect users to the API URL when short URL resolves

## Testing
- `pnpm --filter "./web" lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_b_686da9fe94908332b5499e51225ea3eb